### PR TITLE
Liberado acesso para rota hello

### DIFF
--- a/src/main/java/med/voll/api/infra/security/SecurityConfigurations.java
+++ b/src/main/java/med/voll/api/infra/security/SecurityConfigurations.java
@@ -27,6 +27,7 @@ public class SecurityConfigurations {
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 .and().authorizeHttpRequests()
                 .requestMatchers(HttpMethod.POST, "/login").permitAll()
+		.requestMatchers(HttpMethod.GET, "/hello").permitAll()
                 .requestMatchers("/v3/api-docs/**", "/swagger-ui.html", "/swagger-ui/**").permitAll()
                 .anyRequest().authenticated()
                 .and().addFilterBefore(securityFilter, UsernamePasswordAuthenticationFilter.class)


### PR DESCRIPTION
Como o projeto está sendo usado no 2º Challenge de Devops, acredito ser interessante ter uma rota publica para quem fizer o deploy poder bater no endpoint e receber uma resposta no navegador. Assim a pessoa vai ter mais um feedback visual além do console.

Por ser uma alteração pequena, acredito que não vai impactar os alunos do curso de Spring.